### PR TITLE
protocolVersion is mandatory as version 0 is deprecated starting from MongoDB 4

### DIFF
--- a/replicaset.go
+++ b/replicaset.go
@@ -421,9 +421,10 @@ func currentConfig(session *mgo.Session) (*Config, error) {
 // Config is the document stored in mongodb that defines the servers in the
 // replica set
 type Config struct {
-	Name    string   `bson:"_id"`
-	Version int      `bson:"version"`
-	Members []Member `bson:"members"`
+	Name            string   `bson:"_id"`
+	ProtocolVersion int64    `bson:"protocolVersion"`
+	Version         int      `bson:"version"`
+	Members         []Member `bson:"members"`
 }
 
 // StepDownPrimary asks the current mongo primary to step down.


### PR DESCRIPTION
Without this field, trying to call `juju/replicaset.Add(...)` returns the error:

```
Support for replication protocol version 0 was removed in MongoDB 4.0. Downgrade to MongoDB version 3.6 and upgrade your protocol version to 1 before upgrading your MongoDB version
```